### PR TITLE
Adds support to handle URL multiple params of same name as an arrays

### DIFF
--- a/muxtagconfig.go
+++ b/muxtagconfig.go
@@ -5,8 +5,10 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/gorilla/mux"
+	"strings"
+
 	"github.com/Experticity/tagconfig"
+	"github.com/gorilla/mux"
 )
 
 // ParseMuxRequestToStruct is a convenience method so to wrap the operations of creating a MuxURLGetter and running
@@ -65,9 +67,16 @@ func (mg *MuxURLGetter) Get(key string, f reflect.StructField) (v string) {
 	return ""
 }
 
-func tryURLValues(key string, vs url.Values) (v string, present bool) {
-	v = vs.Get(key)
-	present = v != ""
+func tryURLValues(key string, vs url.Values) (pVal string, present bool) {
+	p := vs[key]
+	if len(p) == 1 {
+		pVal = p[0]
+	} else if len(p) == 0 {
+		pVal = ""
+	} else {
+		pVal = strings.Join(p[:], ",")
+	}
+	present = pVal != ""
 
 	return
 }

--- a/muxtagconfig_test.go
+++ b/muxtagconfig_test.go
@@ -1,4 +1,4 @@
-package muxtagconfig_test
+package muxtagconfig
 
 import (
 	"encoding/json"
@@ -7,10 +7,9 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/Experticity/tagconfig"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	. "github.com/Experticity/muxtagconfig"
-	"github.com/Experticity/tagconfig"
 )
 
 type HackerReferences struct {
@@ -18,6 +17,10 @@ type HackerReferences struct {
 	SuperComputer string `mux.url:"super.computer" mux.form:"true"`
 	Rival         string `mux.url:"rival" mux.param:"true"`
 	Display       string `mux.url:"type" mux.path:"true"`
+}
+
+type SaltyMeats struct {
+	Bacon []string `mux.url:"bacon" mux.param:"true"`
 }
 
 func mockRequest(path string) *http.Request {
@@ -85,6 +88,36 @@ func TestMuxURLParamGet(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, rival, hr.Rival)
+}
+
+func TestMuxMultipleCSVURLParamToSliceGet(t *testing.T) {
+	bacon := "slice"
+	moreBacon := "bits"
+
+	req := mockRequest("/salty/meats/?bacon=" + bacon + "," + moreBacon)
+
+	hr := &SaltyMeats{}
+	mug := &MuxURLGetter{req}
+
+	err := tagconfig.Process(mug, hr)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{bacon, moreBacon}, hr.Bacon)
+}
+
+func TestMuxMultipleURLParamToSliceGet(t *testing.T) {
+	bacon := "slice"
+	moreBacon := "bits"
+
+	req := mockRequest("/salty/meats/?bacon=" + bacon + "&bacon=" + moreBacon)
+
+	hr := &SaltyMeats{}
+	mug := &MuxURLGetter{Request: req}
+
+	err := tagconfig.Process(mug, hr)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{bacon, moreBacon}, hr.Bacon)
 }
 
 func TestMuxURLPathVariableGet(t *testing.T) {


### PR DESCRIPTION
request param array in the form of `?bacon=slice&bacon=bits` will now parse all values into the target slice instead of just the first value.